### PR TITLE
malformed error message to client

### DIFF
--- a/function_to_be_taken_care_of
+++ b/function_to_be_taken_care_of
@@ -1,0 +1,2 @@
+xmlReadDoc -> checks for the format of input data,whether xml or not.If yes, returns the nc_msg->doc
+xmlDocGetRootElement -> get root element from the xml

--- a/src/session.c
+++ b/src/session.c
@@ -2286,7 +2286,12 @@ malformed_msg:
 		}
 		nc_reply_free(reply);
 	}
-
+	reply = nc_reply_error(nc_err_new(NC_ERR_MALFORMED_MSG));
+  	if (nc_session_send_reply(session, NULL, reply) == 0) {
+        ERROR("Unable to send the \'Malformed message\' reply");
+        nc_session_close(session, NC_SESSION_TERM_OTHER);
+        return (NC_MSG_UNKNOWN);
+  	}
 	ERROR("Malformed message received, closing the session %s.", session->session_id);
 	nc_session_close(session, NC_SESSION_TERM_OTHER);
 

--- a/src/session.h
+++ b/src/session.h
@@ -67,6 +67,7 @@ extern "C" {
  * @param[in] capabilities List of capabilities supported by the session.
  * @return Structure describing a dummy NETCONF session or NULL in case of an error.
  */
+struct nc_session* nc_session_dummy_k(const char* username, const char* hostname, struct nc_cpblts *capabilities);
 struct nc_session* nc_session_dummy(const char* sid, const char* username, const char* hostname, struct nc_cpblts *capabilities);
 
 /**
@@ -76,6 +77,10 @@ struct nc_session* nc_session_dummy(const char* sid, const char* username, const
  * @param session Session to be monitored;
  * @return 0 on success, non-zero on error.
  */
+void print_dbg(int);
+unsigned long get_last_session();
+NC_MSG_TYPE nc_session_recv_rpc_k(struct nc_session* session, int timeout, nc_rpc** rpc);
+
 int nc_session_monitor(struct nc_session* session);
 
 /**
@@ -334,7 +339,7 @@ int nc_session_send_notif(struct nc_session* session, const nc_ntf* ntf);
  * This function is supposed to be performed only by NETCONF servers.
  *
  * @param[in] session NETCONF session to use.
- * @param[in] timeout Timeout in microseconds, -1 for infinite timeout, 0 for
+ * @param[in] timeout Timeout in milliseconds, -1 for infinite timeout, 0 for
  * non-blocking
  * @param[out] rpc Received \<rpc\>
  * @return
@@ -351,7 +356,7 @@ NC_MSG_TYPE nc_session_recv_rpc(struct nc_session* session, int timeout, nc_rpc*
  * This function is supposed to be performed only by NETCONF clients.
  *
  * @param[in] session NETCONF session to use.
- * @param[in] timeout Timeout in microseconds, -1 for infinite timeout, 0 for
+ * @param[in] timeout Timeout in milliseconds, -1 for infinite timeout, 0 for
  * non-blocking
  * @param[out] reply Received \<rpc-reply\>
  * @return
@@ -375,7 +380,7 @@ NC_MSG_TYPE nc_session_recv_reply(struct nc_session* session, int timeout, nc_re
  * This function is supposed to be performed only by NETCONF clients.
  *
  * @param[in] session NETCONF session to use.
- * @param[in] timeout Timeout in microseconds, -1 for infinite timeout, 0 for
+ * @param[in] timeout Timeout in milliseconds, -1 for infinite timeout, 0 for
  * non-blocking
  * @param[out] ntf Received \<notification\> message
  * @return

--- a/src/session.h
+++ b/src/session.h
@@ -78,7 +78,11 @@ struct nc_session* nc_session_dummy(const char* sid, const char* username, const
  * @return 0 on success, non-zero on error.
  */
 void print_dbg(int);
+void print_dbg_str(char*);
+void print_dbg_hex(unsigned int);
+void print_dbg_ptr(void*);
 unsigned long get_last_session();
+struct nc_session* nc_cap_get_k(struct nc_session* dsession,struct nc_session* session_new);
 NC_MSG_TYPE nc_session_recv_rpc_k(struct nc_session* session, int timeout, nc_rpc** rpc);
 
 int nc_session_monitor(struct nc_session* session);


### PR DESCRIPTION
When the server gets malformed request, it simply closes and frees the session but doesn't send any response to client. Now client gets malformed error message before the session is closed
